### PR TITLE
Add namespace to Gradle config.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
+        namespace "dev.darttools.flutter_android_volume_keydown"
     }
 }


### PR DESCRIPTION
Gradle 8.0 requires a `namespace` field in the `defaultConfig` section of its config. Flutter 3.27 (the current stable version) requires Gradle 8.0.